### PR TITLE
time print setting

### DIFF
--- a/raspi/raspicamview.py
+++ b/raspi/raspicamview.py
@@ -8,6 +8,7 @@ from multiprocessing import Process,Value
 
 
 def sending(temp_time,received):
+    frame_count=0 # frame number
     #cap = cv.VideoCapture(-1, cv.CAP_V4L2) # 카메라 모듈에서 영상 받아옴
     #cap = cv.VideoCapture("trailer.mp4") #예시 영상
     filepath = "./trailer.mp4"
@@ -18,13 +19,14 @@ def sending(temp_time,received):
         res,frame = cap.read()
         if res:
             re_frame = cv.resize(frame, (224,224), 0, 0, cv.INTER_LINEAR)
-            if received.value==1:
-                with temp_time.get_lock():
-                    temp_time.value=time()
-                with received.get_lock():
-                    received.value=0
+            # if received.value==1:
+            #     with temp_time.get_lock():
+            #         temp_time.value=time()
+            #     with received.get_lock():
+            #         received.value=0
+            print(f'Sending Time={time()*100}ms, frmae number={frame_count}')
             out.write(re_frame)
-            cv.imshow("Send", re_frame)
+            #cv.imshow("Send", re_frame)
             if cv.waitKey(20) == 27:
                 break
     cap.release()
@@ -32,6 +34,7 @@ def sending(temp_time,received):
     cv.destroyWindow("send")
 
 def receive(temp_time,received):
+    frame_count=0# frame number
     print('before writer open')
     cap =  cv.VideoCapture('srtsrc uri="srt://192.168.0.11:9888?mode=caller" ! application/x-rtp ! rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! appsink', cv.CAP_GSTREAMER)
     #cap = cv.VideoCapture('udpsrc port=9888 ! application/x-rtp ! rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! appsink', cv.CAP_GSTREAMER)
@@ -41,20 +44,17 @@ def receive(temp_time,received):
     while True:
         res, frame = cap.read()
         if res:
-            with temp_time.get_lock():
-<<<<<<< HEAD
-                print('Receive image Latency : ',(time()-temp_time.value)*100,'ms')
-=======
-                if count > 0 :
-                    avg += (time()-temp_time.value) *100
-                #print('Receive image Latency : ',(time()-temp_time.value)*100,'ms')
->>>>>>> e28998b9b783746a9a353ed7612c96c34ac007e6
-            with received.get_lock():
-                received.value=1
-            count += 1
-            cv.imshow("receive", frame)
-            if count == 360 :
-                print('average : %6.2fms' % (avg / count))
+            # with temp_time.get_lock():
+            #     if count > 0 :
+            #         avg += (time()-temp_time.value) *100
+            #     #print('Receive image Latency : ',(time()-temp_time.value)*100,'ms')
+            # with received.get_lock():
+            #     received.value=1
+            # count += 1
+            print(f'Receiving Time={time()*100}ms, frmae number={frame_count}')
+            #cv.imshow("receive", frame)
+            # if count == 360 :
+            #     print('average : %6.2fms' % (avg / count))
             if cv.waitKey(20) == 27:
                 break
     cap.release()


### PR DESCRIPTION
 imshow랑 기존의 시간 측정 코드는 모두 주석 달았음 실행시키면 sending의 경우 프레임을 전송하기 적전의 시간을 출력하고 receiving의 경우 프레임을 전송받은 직후의 시간을 출력할 거임, 각 출력은 프레임 번호가 붙어 있으니까 같은 번호가 있는 것 끼리 시간 차를 구하면 레이턴시를 구할 수 있을거임